### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const TimerRepository = require('./dist/commonjs/index').TimerRepository;
+
+function registerInContainer(container) {
+
+  container.register('TimerRepository', TimerRepository)
+    .configure('process_engine:timer_repository')
+    .singleton();
+}
+
+module.exports.registerInContainer = registerInContainer;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@essential-projects/sequelize_connection_manager": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^13.0.0",
+    "@process-engine/process_engine_contracts": "feature~remove_old_datastore_implementation",
     "loggerhythm": "^3.0.3",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Uses sequelize to access and manipulate timers.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@essential-projects/sequelize_connection_manager": "^1.0.0",
     "@process-engine/process_engine_contracts": "feature~remove_old_datastore_implementation",
     "loggerhythm": "^3.0.3",
+    "moment": "^2.22.2",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",
     "sequelize": "^4.38.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@essential-projects/sequelize_connection_manager": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~remove_old_datastore_implementation",
+    "@process-engine/process_engine_contracts": "^14.0.0",
     "loggerhythm": "^3.0.3",
     "moment": "^2.22.2",
     "pg": "^7.4.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './timer_repository';

--- a/src/model_loader.ts
+++ b/src/model_loader.ts
@@ -1,0 +1,16 @@
+import * as Sequelize from 'sequelize';
+
+import {
+  defineTimer,
+  ITimerAttributes,
+  Timer,
+} from './schemas/index';
+
+export async function loadModels(sequelizeInstance: Sequelize.Sequelize): Promise<Sequelize.Model<Timer, ITimerAttributes>> {
+
+  const timerModel: Sequelize.Model<Timer, ITimerAttributes> = defineTimer(sequelizeInstance);
+
+  await sequelizeInstance.sync();
+
+  return timerModel;
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './timer';

--- a/src/schemas/timer.ts
+++ b/src/schemas/timer.ts
@@ -6,7 +6,7 @@ export interface ITimerAttributes {
   timerIsoString: string;
   timerRule: string;
   eventName: string;
-  lastElapsed: Date;
+  lastElapsed?: Date;
 }
 
 export type Timer = Sequelize.Instance<ITimerAttributes> & ITimerAttributes;
@@ -20,7 +20,6 @@ export function defineTimer(sequelize: Sequelize.Sequelize): any {
     },
     timerType: {
       type: Sequelize.NUMBER,
-      unique: true,
       allowNull: false,
     },
     timerIsoString: {
@@ -37,7 +36,8 @@ export function defineTimer(sequelize: Sequelize.Sequelize): any {
     },
     lastElapsed: {
       type: Sequelize.DATE,
-      allowNull: false,
+      allowNull: true,
+      defaultValue: undefined,
     },
   };
 

--- a/src/schemas/timer.ts
+++ b/src/schemas/timer.ts
@@ -19,7 +19,7 @@ export function defineTimer(sequelize: Sequelize.Sequelize): any {
       defaultValue: Sequelize.UUIDV4,
     },
     type: {
-      type: Sequelize.NUMBER,
+      type: Sequelize.INTEGER,
       allowNull: false,
     },
     expirationDate: {
@@ -37,7 +37,6 @@ export function defineTimer(sequelize: Sequelize.Sequelize): any {
     lastElapsed: {
       type: Sequelize.DATE,
       allowNull: true,
-      defaultValue: undefined,
     },
   };
 

--- a/src/schemas/timer.ts
+++ b/src/schemas/timer.ts
@@ -1,0 +1,45 @@
+import * as Sequelize from 'sequelize';
+
+export interface ITimerAttributes {
+  id: string;
+  timerType: number;
+  timerIsoString: string;
+  timerRule: string;
+  eventName: string;
+  lastElapsed: Date;
+}
+
+export type Timer = Sequelize.Instance<ITimerAttributes> & ITimerAttributes;
+
+export function defineTimer(sequelize: Sequelize.Sequelize): any {
+  const attributes: SequelizeAttributes<ITimerAttributes> = {
+    id: {
+      type: Sequelize.UUID,
+      primaryKey: true,
+      defaultValue: Sequelize.UUIDV4,
+    },
+    timerType: {
+      type: Sequelize.NUMBER,
+      unique: true,
+      allowNull: false,
+    },
+    timerIsoString: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    timerRule: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    eventName: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    lastElapsed: {
+      type: Sequelize.DATE,
+      allowNull: false,
+    },
+  };
+
+  return sequelize.define<Timer, ITimerAttributes>('Timer', attributes);
+}

--- a/src/schemas/timer.ts
+++ b/src/schemas/timer.ts
@@ -2,9 +2,9 @@ import * as Sequelize from 'sequelize';
 
 export interface ITimerAttributes {
   id: string;
-  timerType: number;
-  timerIsoString: string;
-  timerRule: string;
+  type: number;
+  expirationDate?: Date; // Only used, if timer type is "once"
+  rule?: string; // Only used, if timer type is "periodic"
   eventName: string;
   lastElapsed?: Date;
 }
@@ -18,17 +18,17 @@ export function defineTimer(sequelize: Sequelize.Sequelize): any {
       primaryKey: true,
       defaultValue: Sequelize.UUIDV4,
     },
-    timerType: {
+    type: {
       type: Sequelize.NUMBER,
       allowNull: false,
     },
-    timerIsoString: {
-      type: Sequelize.STRING,
-      allowNull: false,
+    expirationDate: {
+      type: Sequelize.DATE,
+      allowNull: true,
     },
-    timerRule: {
+    rule: {
       type: Sequelize.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     eventName: {
       type: Sequelize.STRING,

--- a/src/timer_repository.ts
+++ b/src/timer_repository.ts
@@ -7,6 +7,8 @@ import * as Sequelize from 'sequelize';
 import {loadModels} from './model_loader';
 import {ITimerAttributes, Timer as TimerModel} from './schemas';
 
+import * as moment from 'moment';
+
 export class TimerRepository implements ITimerRepository {
 
   public config: Sequelize.Options;
@@ -52,9 +54,9 @@ export class TimerRepository implements ITimerRepository {
   public async create(timerToStore: Runtime.Types.Timer): Promise<string> {
 
     const createParams: any = {
-      timerType: timerToStore.timerType,
-      timerIsoString: timerToStore.timerIsoString,
-      timerRule: JSON.stringify(timerToStore.timerRule),
+      type: timerToStore.type,
+      expirationDate: timerToStore.expirationDate.toDate(),
+      rule: JSON.stringify(timerToStore.rule),
       eventName: timerToStore.eventName,
       lastElapsed: timerToStore.lastElapsed,
     };
@@ -93,9 +95,9 @@ export class TimerRepository implements ITimerRepository {
 
     const timer: Runtime.Types.Timer = new Runtime.Types.Timer();
     timer.id = dataModel.id;
-    timer.timerType = dataModel.timerType;
-    timer.timerIsoString = dataModel.timerIsoString;
-    timer.timerRule = JSON.parse(dataModel.timerRule);
+    timer.type = dataModel.type;
+    timer.expirationDate = moment(dataModel.expirationDate);
+    timer.rule = JSON.parse(dataModel.rule);
     timer.eventName = dataModel.eventName;
     timer.lastElapsed = dataModel.lastElapsed;
 

--- a/src/timer_repository.ts
+++ b/src/timer_repository.ts
@@ -55,8 +55,8 @@ export class TimerRepository implements ITimerRepository {
 
     const createParams: any = {
       type: timerToStore.type,
-      expirationDate: timerToStore.expirationDate.toDate(),
-      rule: JSON.stringify(timerToStore.rule),
+      expirationDate: timerToStore.expirationDate ? timerToStore.expirationDate.toDate() : null,
+      rule: timerToStore.rule ? JSON.stringify(timerToStore.rule): null,
       eventName: timerToStore.eventName,
       lastElapsed: timerToStore.lastElapsed,
     };
@@ -96,8 +96,8 @@ export class TimerRepository implements ITimerRepository {
     const timer: Runtime.Types.Timer = new Runtime.Types.Timer();
     timer.id = dataModel.id;
     timer.type = dataModel.type;
-    timer.expirationDate = moment(dataModel.expirationDate);
-    timer.rule = JSON.parse(dataModel.rule);
+    timer.expirationDate = dataModel.expirationDate ? moment(dataModel.expirationDate) : undefined;
+    timer.rule = dataModel.rule ? JSON.parse(dataModel.rule) : undefined;
     timer.eventName = dataModel.eventName;
     timer.lastElapsed = dataModel.lastElapsed;
 

--- a/src/timer_repository.ts
+++ b/src/timer_repository.ts
@@ -72,6 +72,23 @@ export class TimerRepository implements ITimerRepository {
     });
   }
 
+  public async setLastElapsedById(timerId: string, lastElapsed: Date): Promise<void> {
+
+    const matchingTimer: TimerModel = await this.timerModel.findOne({
+      where: {
+        id: timerId,
+      },
+    });
+
+    if (!matchingTimer) {
+      throw new Error(`timer with id '${timerId}' not found!`);
+    }
+
+    matchingTimer.lastElapsed = lastElapsed;
+
+    matchingTimer.save();
+  }
+
   private _convertToTimerRuntimeObject(dataModel: TimerModel): Runtime.Types.Timer {
 
     const timer: Runtime.Types.Timer = new Runtime.Types.Timer();

--- a/src/timer_repository.ts
+++ b/src/timer_repository.ts
@@ -1,0 +1,87 @@
+import {ITimerRepository, Runtime} from '@process-engine/process_engine_contracts';
+
+import {getConnection} from '@essential-projects/sequelize_connection_manager';
+
+import * as Sequelize from 'sequelize';
+
+import {loadModels} from './model_loader';
+import {ITimerAttributes, Timer as TimerModel} from './schemas';
+
+export class TimerRepository implements ITimerRepository {
+
+  public config: Sequelize.Options;
+
+  private _timerModel: Sequelize.Model<TimerModel, ITimerAttributes>;
+
+  private sequelize: Sequelize.Sequelize;
+
+  private get timerModel(): Sequelize.Model<TimerModel, ITimerAttributes> {
+    return this._timerModel;
+  }
+
+  public async initialize(): Promise<void> {
+    this.sequelize = await getConnection(this.config);
+    this._timerModel = await loadModels(this.sequelize);
+  }
+
+  public async getAll(): Promise<Array<Runtime.Types.Timer>> {
+
+    const result: Array<TimerModel> = await this.timerModel.findAll();
+    const runtimeProcessDefinitions: Array<Runtime.Types.Timer> = result.map(this._convertToTimerRuntimeObject);
+
+    return runtimeProcessDefinitions;
+  }
+
+  public async getById(timerId: string): Promise<Runtime.Types.Timer> {
+
+    const matchingTimer: TimerModel = await this.timerModel.findOne({
+      where: {
+        id: timerId,
+      },
+    });
+
+    if (!matchingTimer) {
+      throw new Error(`timer with id '${timerId}' not found!`);
+    }
+
+    const timerRuntimeObject: Runtime.Types.Timer = this._convertToTimerRuntimeObject(matchingTimer);
+
+    return timerRuntimeObject;
+  }
+
+  public async create(timerToStore: Runtime.Types.Timer): Promise<string> {
+
+    const createParams: any = {
+      timerType: timerToStore.timerType,
+      timerIsoString: timerToStore.timerIsoString,
+      timerRule: JSON.stringify(timerToStore.timerRule),
+      eventName: timerToStore.eventName,
+      lastElapsed: timerToStore.lastElapsed,
+    };
+
+    const result: TimerModel = await this.timerModel.create(createParams);
+
+    return result.id;
+  }
+
+  public async removeById(timerId: string): Promise<void> {
+    await this.timerModel.destroy({
+      where: {
+        id: timerId,
+      },
+    });
+  }
+
+  private _convertToTimerRuntimeObject(dataModel: TimerModel): Runtime.Types.Timer {
+
+    const timer: Runtime.Types.Timer = new Runtime.Types.Timer();
+    timer.id = dataModel.id;
+    timer.timerType = dataModel.timerType;
+    timer.timerIsoString = dataModel.timerIsoString;
+    timer.timerRule = JSON.parse(dataModel.timerRule);
+    timer.eventName = dataModel.eventName;
+    timer.lastElapsed = dataModel.lastElapsed;
+
+    return timer;
+  }
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,12 @@
+import {DataTypeAbstract, DefineAttributeColumnOptions} from 'sequelize';
+
+type SequelizeAttribute = string | DataTypeAbstract | DefineAttributeColumnOptions;
+
+// This will allow to globally use "SequelizeAttribute" instead of always having to declare
+// "string | DataTypeAbstract | DefineAttributeColumnOptions"
+// See the schemas for usage examples.
+declare global {
+  type SequelizeAttributes<T extends { [key: string]: any }> = {
+    [P in keyof T]: SequelizeAttribute
+  };
+}


### PR DESCRIPTION
## What did you change?

Implement the sequelize-based repository for storing timers.

## How can others test the changes?

Use the repository to store and access timers.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
